### PR TITLE
Add command options for metadata downloading by ID (artist, image, tag, series)

### DIFF
--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -926,6 +926,41 @@ class PixivDBManager(object):
             self.conn.commit()
         except BaseException:
             print("Error at insertSeries():", str(sys.exc_info()))
+
+    def updateSeries(self, series_id, series_title, series_type, series_desc=None):
+        try:
+            c = self.conn.cursor()
+            c.execute(
+                """UPDATE pixiv_master_series
+                      SET series_title = ?,
+                          series_type = ?,
+                          series_description = ?,
+                          last_update_date = datetime('now')
+                      WHERE series_id = ?""",
+                (series_title, series_type, series_desc, series_id),
+            )
+            self.conn.commit()
+        except BaseException:
+            print("Error at updateSeries():", str(sys.exc_info()))
+
+    def deleteImageToSeriesBySeriesId(self, series_id):
+        try:
+            c = self.conn.cursor()
+            c.execute("""DELETE FROM pixiv_image_to_series WHERE series_id = ?""", (series_id,))
+            self.conn.commit()
+        except BaseException:
+            print("Error at deleteImageToSeriesBySeriesId():", str(sys.exc_info()))
+
+    def deleteImageToSeriesByImageIds(self, image_ids):
+        if image_ids is None or len(image_ids) == 0:
+            return
+        try:
+            c = self.conn.cursor()
+            placeholders = ','.join('?' for _ in image_ids)
+            c.execute(f"""DELETE FROM pixiv_image_to_series WHERE image_id IN ({placeholders})""", image_ids)
+            self.conn.commit()
+        except BaseException:
+            print("Error at deleteImageToSeriesByImageIds():", str(sys.exc_info()))
             print("failed")
             raise
         finally:

--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -998,6 +998,19 @@ class PixivDBManager(object):
             self.conn.commit()
         except BaseException:
             print("Error at insertTag():", str(sys.exc_info()))
+
+    def updateTag(self, tag_id):
+        try:
+            c = self.conn.cursor()
+            c.execute(
+                """UPDATE pixiv_master_tag
+                      SET last_update_date = datetime('now')
+                      WHERE tag_id = ?""",
+                (tag_id,),
+            )
+            self.conn.commit()
+        except BaseException:
+            print("Error at updateTag():", str(sys.exc_info()))
             print("failed")
             raise
         finally:

--- a/PixivDBManager.py
+++ b/PixivDBManager.py
@@ -1035,6 +1035,18 @@ class PixivDBManager(object):
         finally:
             c.close()
 
+    def deleteImageToTagByImageId(self, image_id):
+        try:
+            c = self.conn.cursor()
+            c.execute("""DELETE FROM pixiv_image_to_tag WHERE image_id = ?""", (image_id,))
+            self.conn.commit()
+        except BaseException:
+            print("Error at deleteImageToTagByImageId():", str(sys.exc_info()))
+            print("failed")
+            raise
+        finally:
+            c.close()
+
     def insertTagTranslation(self, tag_id, translation_type, translation):
         try:
             c = self.conn.cursor()

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -173,6 +173,7 @@ def menu():
     print(' 18. Download by New Illusts')
     print(' 19. Download by Unlisted image_id')
     print(' m1. Metadata by member_id')
+    print(' m2. Metadata by image_id')
     print(Style.BRIGHT + '── FANBOX '.ljust(PADDING, "─") + Style.RESET_ALL)
     print(' f1. Download from supporting list (FANBOX)')
     print(' f2. Download by artist/creator id (FANBOX)')
@@ -376,6 +377,35 @@ def menu_download_by_image_id(opisvalid, args, options):
                                             artist=None,
                                             image_id=int(image_id),
                                             useblacklist=False)
+
+
+def menu_metadata_by_image_id(opisvalid, args, options):
+    __log__.info('Image metadata mode (m2).')
+    if opisvalid and len(args) > 0:
+        for image_id in args:
+            try:
+                test_id = int(image_id)
+                PixivImageHandler.process_image(sys.modules[__name__],
+                                                __config__,
+                                                artist=None,
+                                                image_id=test_id,
+                                                useblacklist=False,
+                                                metadata_only=True)
+            except BaseException:
+                PixivHelper.print_and_log('error', f"Image ID: {image_id} is not valid")
+                global ERROR_CODE
+                ERROR_CODE = -1
+                continue
+    else:
+        image_ids = input('Image ids: ').rstrip("\r")
+        image_ids = PixivHelper.get_ids_from_csv(image_ids)
+        for image_id in image_ids:
+            PixivImageHandler.process_image(sys.modules[__name__],
+                                            __config__,
+                                            artist=None,
+                                            image_id=int(image_id),
+                                            useblacklist=False,
+                                            metadata_only=True)
 
 
 def menu_download_by_tags(opisvalid, args, options):
@@ -1276,7 +1306,7 @@ def set_console_title(title=''):
 def setup_option_parser():
 
     global __valid_options
-    __valid_options = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', 'm1',
+    __valid_options = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', 'm1', 'm2',
                        'f1', 'f2', 'f3', 'f4', 'f5',
                        's1', 's2',
                        'l', 'd', 'e', 'm', 'b', 'p', 'c')
@@ -1298,6 +1328,7 @@ def setup_option_parser():
 11 - Download images from Member Bookmark           \n
 12 - Download images by Group Id                    \n
 m1 - Metadata by member_id                          \n
+m2 - Metadata by image_id                           \n
 f1 - Download from supporting list (FANBOX)         \n
 f2 - Download by artist/creator id (FANBOX)         \n
 f3 - Download by post id (FANBOX)                   \n
@@ -1504,6 +1535,8 @@ def main_loop(ewd, op_is_valid, selection, np_is_valid_local, args, options):
                 menu_download_by_unlisted_image_id(op_is_valid, args, options)
             elif selection == 'm1':
                 menu_metadata_by_member_id(op_is_valid, args, options)
+            elif selection == 'm2':
+                menu_metadata_by_image_id(op_is_valid, args, options)
             elif selection == "l":
                 menu_export_database_images(op_is_valid, args, options)
             elif selection == 'b':

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -174,6 +174,7 @@ def menu():
     print(' 19. Download by Unlisted image_id')
     print(' m1. Metadata by member_id')
     print(' m2. Metadata by image_id')
+    print(' m3. Metadata by manga series id')
     print(Style.BRIGHT + '── FANBOX '.ljust(PADDING, "─") + Style.RESET_ALL)
     print(' f1. Download from supporting list (FANBOX)')
     print(' f2. Download by artist/creator id (FANBOX)')
@@ -406,6 +407,27 @@ def menu_metadata_by_image_id(opisvalid, args, options):
                                             image_id=int(image_id),
                                             useblacklist=False,
                                             metadata_only=True)
+
+
+def menu_metadata_by_manga_series_id(opisvalid, args, options):
+    __log__.info('Manga Series metadata mode (m3).')
+    manga_series_ids = []
+
+    if opisvalid and len(args) > 0:
+        for manga_series_id in args:
+            if manga_series_id.isdigit():
+                manga_series_ids.append(int(manga_series_id))
+            else:
+                print(f"Possible invalid manga series id = {manga_series_id}")
+    else:
+        manga_series_ids = input('Manga Series IDs: ').rstrip("\r")
+        manga_series_ids = PixivHelper.get_ids_from_csv(manga_series_ids)
+        PixivHelper.print_and_log('info', f"Manga Series IDs: {manga_series_ids}")
+
+    for manga_series_id in manga_series_ids:
+        PixivImageHandler.process_manga_series_metadata(sys.modules[__name__],
+                                                        __config__,
+                                                        manga_series_id)
 
 
 def menu_download_by_tags(opisvalid, args, options):
@@ -1306,7 +1328,7 @@ def set_console_title(title=''):
 def setup_option_parser():
 
     global __valid_options
-    __valid_options = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', 'm1', 'm2',
+    __valid_options = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', 'm1', 'm2', 'm3',
                        'f1', 'f2', 'f3', 'f4', 'f5',
                        's1', 's2',
                        'l', 'd', 'e', 'm', 'b', 'p', 'c')
@@ -1329,6 +1351,7 @@ def setup_option_parser():
 12 - Download images by Group Id                    \n
 m1 - Metadata by member_id                          \n
 m2 - Metadata by image_id                           \n
+m3 - Metadata by manga series id                    \n
 f1 - Download from supporting list (FANBOX)         \n
 f2 - Download by artist/creator id (FANBOX)         \n
 f3 - Download by post id (FANBOX)                   \n
@@ -1537,6 +1560,8 @@ def main_loop(ewd, op_is_valid, selection, np_is_valid_local, args, options):
                 menu_metadata_by_member_id(op_is_valid, args, options)
             elif selection == 'm2':
                 menu_metadata_by_image_id(op_is_valid, args, options)
+            elif selection == 'm3':
+                menu_metadata_by_manga_series_id(op_is_valid, args, options)
             elif selection == "l":
                 menu_export_database_images(op_is_valid, args, options)
             elif selection == 'b':

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -172,6 +172,7 @@ def menu():
     print(' 17. Download by Rank R-18')
     print(' 18. Download by New Illusts')
     print(' 19. Download by Unlisted image_id')
+    print(' m1. Metadata by member_id')
     print(Style.BRIGHT + '── FANBOX '.ljust(PADDING, "─") + Style.RESET_ALL)
     print(' f1. Download from supporting list (FANBOX)')
     print(' f2. Download by artist/creator id (FANBOX)')
@@ -264,6 +265,37 @@ def menu_download_by_member_id(opisvalid, args, options):
 
             current_member = current_member + 1
         except PixivException as ex:
+            PixivHelper.print_and_log('error', f"Member ID: {member_id} is not valid")
+            global ERROR_CODE
+            ERROR_CODE = -1
+            continue
+
+
+def menu_metadata_by_member_id(opisvalid, args, options):
+    __log__.info('Member metadata mode (m1).')
+    current_member = 1
+    member_ids = list()
+
+    if opisvalid and len(args) > 0:
+        for member_id in args:
+            if member_id.isdigit():
+                member_ids.append(int(member_id))
+            else:
+                print(f"Possible invalid member id = {member_id}")
+    else:
+        member_ids = input('Member ids: ').rstrip("\r")
+        member_ids = PixivHelper.get_ids_from_csv(member_ids)
+        PixivHelper.print_and_log('info', f"Member IDs: {member_ids}")
+
+    for member_id in member_ids:
+        try:
+            prefix = f"[{current_member} of {len(member_ids)}] "
+            PixivArtistHandler.process_member_metadata(sys.modules[__name__],
+                                                      __config__,
+                                                      member_id,
+                                                      title_prefix=prefix)
+            current_member = current_member + 1
+        except PixivException:
             PixivHelper.print_and_log('error', f"Member ID: {member_id} is not valid")
             global ERROR_CODE
             ERROR_CODE = -1
@@ -1244,7 +1276,7 @@ def set_console_title(title=''):
 def setup_option_parser():
 
     global __valid_options
-    __valid_options = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19',
+    __valid_options = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', 'm1',
                        'f1', 'f2', 'f3', 'f4', 'f5',
                        's1', 's2',
                        'l', 'd', 'e', 'm', 'b', 'p', 'c')
@@ -1265,6 +1297,7 @@ def setup_option_parser():
 10 - Download by Tag and Member Id                  \n
 11 - Download images from Member Bookmark           \n
 12 - Download images by Group Id                    \n
+m1 - Metadata by member_id                          \n
 f1 - Download from supporting list (FANBOX)         \n
 f2 - Download by artist/creator id (FANBOX)         \n
 f3 - Download by post id (FANBOX)                   \n
@@ -1469,6 +1502,8 @@ def main_loop(ewd, op_is_valid, selection, np_is_valid_local, args, options):
                 menu_download_new_illusts(op_is_valid, args, options)
             elif selection == '19':
                 menu_download_by_unlisted_image_id(op_is_valid, args, options)
+            elif selection == 'm1':
+                menu_metadata_by_member_id(op_is_valid, args, options)
             elif selection == "l":
                 menu_export_database_images(op_is_valid, args, options)
             elif selection == 'b':

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -175,6 +175,7 @@ def menu():
     print(' m1. Metadata by member_id')
     print(' m2. Metadata by image_id')
     print(' m3. Metadata by manga series id')
+    print(' m4. Metadata by tag')
     print(Style.BRIGHT + '── FANBOX '.ljust(PADDING, "─") + Style.RESET_ALL)
     print(' f1. Download from supporting list (FANBOX)')
     print(' f2. Download by artist/creator id (FANBOX)')
@@ -428,6 +429,15 @@ def menu_metadata_by_manga_series_id(opisvalid, args, options):
         PixivImageHandler.process_manga_series_metadata(sys.modules[__name__],
                                                         __config__,
                                                         manga_series_id)
+
+
+def menu_metadata_by_tag(opisvalid, args, options):
+    __log__.info('Tag metadata mode (m4).')
+    if opisvalid and len(args) > 0:
+        tags = args
+    else:
+        tags = input('Tags (comma-separated): ').rstrip("\r")
+    PixivTagsHandler.process_tag_metadata(sys.modules[__name__], __config__, tags)
 
 
 def menu_download_by_tags(opisvalid, args, options):
@@ -1328,7 +1338,7 @@ def set_console_title(title=''):
 def setup_option_parser():
 
     global __valid_options
-    __valid_options = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', 'm1', 'm2', 'm3',
+    __valid_options = ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', 'm1', 'm2', 'm3', 'm4',
                        'f1', 'f2', 'f3', 'f4', 'f5',
                        's1', 's2',
                        'l', 'd', 'e', 'm', 'b', 'p', 'c')
@@ -1352,6 +1362,7 @@ def setup_option_parser():
 m1 - Metadata by member_id                          \n
 m2 - Metadata by image_id                           \n
 m3 - Metadata by manga series id                    \n
+m4 - Metadata by tag                                \n
 f1 - Download from supporting list (FANBOX)         \n
 f2 - Download by artist/creator id (FANBOX)         \n
 f3 - Download by post id (FANBOX)                   \n
@@ -1562,6 +1573,8 @@ def main_loop(ewd, op_is_valid, selection, np_is_valid_local, args, options):
                 menu_metadata_by_image_id(op_is_valid, args, options)
             elif selection == 'm3':
                 menu_metadata_by_manga_series_id(op_is_valid, args, options)
+            elif selection == 'm4':
+                menu_metadata_by_tag(op_is_valid, args, options)
             elif selection == "l":
                 menu_export_database_images(op_is_valid, args, options)
             elif selection == 'b':

--- a/PixivUtil2.py
+++ b/PixivUtil2.py
@@ -437,7 +437,11 @@ def menu_metadata_by_tag(opisvalid, args, options):
         tags = args
     else:
         tags = input('Tags (comma-separated): ').rstrip("\r")
-    PixivTagsHandler.process_tag_metadata(sys.modules[__name__], __config__, tags)
+    filter_mode = options.tag_metadata_filter
+    if not opisvalid:
+        filter_prompt = "Tag metadata filter [none/pixpedia/translation/pixpedia_or_translation, default is none]: "
+        filter_mode = input(filter_prompt).rstrip("\r") or "none"
+    PixivTagsHandler.process_tag_metadata(sys.modules[__name__], __config__, tags, filter_mode=filter_mode)
 
 
 def menu_download_by_tags(opisvalid, args, options):
@@ -1506,6 +1510,10 @@ Used in option e, m, p''')
  y - include sketch database.                       \n
  n - don't include sketch database.                 \n
  o - only export sketch database.''')
+    parser.add_option('--tmf', '--tag_metadata_filter',
+                      dest='tag_metadata_filter',
+                      default='none',
+                      help='''Filter for tag metadata (m4). Valid: none, pixpedia, translation, pixpedia_or_translation.''')
     return parser
 
 

--- a/common/PixivBrowserFactory.py
+++ b/common/PixivBrowserFactory.py
@@ -31,7 +31,7 @@ from model.PixivModelSketch import SketchArtist, SketchPost
 from model.PixivNovel import MAX_LIMIT, NovelSeries, PixivNovel
 from common.PixivOAuth import PixivOAuth
 from model.PixivRanking import PixivNewIllust, PixivRanking
-from model.PixivTags import PixivTags
+from model.PixivTags import PixivTags, PixivTag
 
 defaultCookieJar = None
 defaultConfig = None
@@ -950,7 +950,27 @@ class PixivBrowser(mechanize.Browser):
                     PixivHelper.dump_html(f"Dump for SearchTags {tags}.html", response_page)
                     raise
 
-        return (result, response_page)
+            return (result, response_page)
+
+    def getTagInfo(self, tag, lang=None) -> PixivTag:
+        if tag is None or len(tag) == 0:
+            raise PixivException("Tag is empty.", errorCode=PixivException.OTHER_ERROR)
+
+        encoded_tag = PixivHelper.encode_tags(tag)
+        url = f'https://www.pixiv.net/ajax/search/tags/{encoded_tag}'
+        if lang is None:
+            lang = self._locale
+        if lang:
+            url = f'{url}?lang={lang}'
+
+        response = self._get_from_cache(url)
+        if response is None:
+            res = self.open_with_retry(url)
+            response = res.read()
+            res.close()
+            self._put_to_cache(url, response)
+
+        return PixivTag(json.loads(response))
 
     def handleDebugTagSearchPage(self, response, url):
         if self._config.enableDump:

--- a/common/PixivHelper.py
+++ b/common/PixivHelper.py
@@ -678,10 +678,15 @@ def get_ids_from_csv(ids_str, is_string=False):
 
 def coalesce(*values):
     """
-    Return the first non-None value, or None if all values are None.
+    Return the first value that is not None and not an empty string.
+    If none match, return the first value that is not an empty string.
+    Otherwise, return None.
     """
     for value in values:
-        if value is not None:
+        if value is not None and not (isinstance(value, str) and value == ""):
+            return value
+    for value in values:
+        if not (isinstance(value, str) and value == ""):
             return value
     return None
 

--- a/common/PixivHelper.py
+++ b/common/PixivHelper.py
@@ -676,6 +676,16 @@ def get_ids_from_csv(ids_str, is_string=False):
     return ids
 
 
+def coalesce(*values):
+    """
+    Return the first non-None value, or None if all values are None.
+    """
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
 def clear_all():
     all_vars = [var for var in globals() if (var[:2], var[-2:]) != ("__", "__") and var != "clear_all"]
     for var in all_vars:

--- a/handler/PixivArtistHandler.py
+++ b/handler/PixivArtistHandler.py
@@ -13,6 +13,76 @@ import handler.PixivImageHandler as PixivImageHandler
 from common.PixivException import PixivException
 
 
+def process_member_metadata(caller,
+                            config,
+                            member_id,
+                            bookmark=False,
+                            tags=None,
+                            title_prefix="",
+                            notifier=None):
+    # caller function/method
+    # TODO: ideally to be removed or passed as argument
+    db = caller.__dbManager__
+
+    if notifier is None:
+        notifier = PixivHelper.dummy_notifier
+
+    list_page = None
+
+    msg = Fore.YELLOW + Style.BRIGHT + f'Processing Member Metadata: {member_id}' + Style.RESET_ALL
+    PixivHelper.print_and_log('info', msg)
+    notifier(type="MEMBER", message=msg)
+
+    try:
+        caller.set_console_title(f"{title_prefix}MemberId: {member_id}")
+        try:
+            (artist, list_page) = PixivBrowserFactory.getBrowser().getMemberPage(member_id, 1, bookmark, tags, r18mode=config.r18mode, throw_empty_error=True)
+        except PixivException as ex:
+            caller.ERROR_CODE = ex.errorCode
+            PixivHelper.print_and_log('info', f'Member ID ({member_id}): {ex}')
+            if list_page is None:
+                list_page = ex.htmlPage
+            if list_page is not None:
+                PixivHelper.dump_html(f"Dump for {member_id} Error Code {ex.errorCode}.html", list_page)
+            if ex.errorCode == PixivException.USER_ID_NOT_EXISTS or ex.errorCode == PixivException.USER_ID_SUSPENDED:
+                db.setIsDeletedFlagForMemberId(int(member_id))
+                PixivHelper.print_and_log('info', f'Set IsDeleted for MemberId: {member_id} not exist.')
+            elif ex.errorCode == PixivException.OTHER_MEMBER_ERROR:
+                PixivHelper.print_and_log(None, ex.message)
+                caller.__errorList.append(dict(type="Member", id=str(member_id), message=ex.message, exception=ex))
+            return
+
+        PixivHelper.print_and_log(None, f'{Fore.LIGHTGREEN_EX}{"Member Name":14}:{Style.RESET_ALL} {artist.artistName}')
+        PixivHelper.print_and_log(None, f'{Fore.LIGHTGREEN_EX}{"Member Avatar":14}:{Style.RESET_ALL} {artist.artistAvatar}')
+        PixivHelper.print_and_log(None, f'{Fore.LIGHTGREEN_EX}{"Member Token":14}:{Style.RESET_ALL} {artist.artistToken}')
+        PixivHelper.print_and_log(None, f'{Fore.LIGHTGREEN_EX}{"Member Backgrd":14}:{Style.RESET_ALL} {artist.artistBackground}')
+
+        db.insertNewMember(int(member_id), member_token=artist.artistToken)
+        db.updateMemberName(member_id, artist.artistName, artist.artistToken)
+        db.updateLastDownloadDate(member_id)
+
+        PixivHelper.print_and_log("info", f"Member_id: {member_id} metadata updated.")
+    except KeyboardInterrupt:
+        raise
+    except Exception:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        traceback.print_exception(exc_type, exc_value, exc_traceback)
+        PixivHelper.print_and_log('error', f'Error at process_member_metadata(): {sys.exc_info()}')
+        try:
+            if list_page is not None:
+                dump_filename = f'Error page for member {member_id}.html'
+                PixivHelper.dump_html(dump_filename, list_page)
+                PixivHelper.print_and_log('error', f"Dumping html to: {dump_filename}")
+        except BaseException:
+            PixivHelper.print_and_log('error', f'Cannot dump page for member_id: {member_id}')
+        raise
+    finally:
+        try:
+            PixivBrowserFactory.getBrowser(config=config).clear_history()
+        except BaseException:
+            pass
+        gc.collect()
+
 def process_member(caller,
                    config,
                    member_id,

--- a/handler/PixivImageHandler.py
+++ b/handler/PixivImageHandler.py
@@ -653,6 +653,9 @@ def process_image(caller,
 
             # Save tags if enabled
             if config.autoAddTag:
+                if metadata_only:
+                    # assume existing tag maps are oudated, and re-apply tag mappings.
+                    db.deleteImageToTagByImageId(image_id)
                 tags = image.tags
                 if tags:
                     for tag_data in tags:
@@ -667,6 +670,9 @@ def process_image(caller,
                                     db.insertTagTranslation(tag_id, locale, tag_data.translation_data[locale])
 
             # Save series data if enabled.
+            if config.autoAddSeries and metadata_only:
+                # assume existing series data (if any) are outdated, and re-apply series mappings.
+                db.deleteImageToSeriesByImageIds([image_id])
             if config.autoAddSeries and (seriesNavData := image.seriesNavData):
                 seriesId = seriesNavData.get("seriesId")
                 seriesType = seriesNavData.get("seriesType")

--- a/handler/PixivImageHandler.py
+++ b/handler/PixivImageHandler.py
@@ -642,7 +642,10 @@ def process_image(caller,
 
             if metadata_only:
                 filename = r[0] if in_db else 'N/A'
-            db.updateImage(image.imageId, image.imageTitle, filename, image.imageMode)
+
+            # Only update caption when autoAddCaption is enabled; otherwise preserve existing value.
+            caption_to_update = image.imageCaption if config.autoAddCaption else None
+            db.updateImage(image.imageId, image.imageTitle, filename, image.imageMode, caption=caption_to_update)
 
             if len(manga_files) > 0:
                 if archive_mode_update_manga_image_paths:

--- a/handler/PixivImageHandler.py
+++ b/handler/PixivImageHandler.py
@@ -174,20 +174,20 @@ def process_image(caller,
                 result = PixivConstant.PIXIVUTIL_OK
 
         # feature #1189 AI filtering
-        if config.aiDisplayFewer and image.ai_type == 2:
+        if not metadata_only and config.aiDisplayFewer and image.ai_type == 2:
             PixivHelper.print_and_log('warn', f'Skipping image_id: {image_id} – blacklisted due to aiDisplayFewer is set to True and aiType = {image.ai_type}.')
             download_image_flag = False
             result = PixivConstant.PIXIVUTIL_SKIP_BLACKLIST
 
         # date validation and blacklist tag validation
-        if config.dateDiff > 0:
+        if not metadata_only and config.dateDiff > 0:
             if image.worksDateDateTime is not None and image.worksDateDateTime != datetime.datetime.fromordinal(1).replace(tzinfo=datetime_z.utc):
                 if image.worksDateDateTime < (datetime.datetime.today() - datetime.timedelta(config.dateDiff)).replace(tzinfo=datetime_z.utc):
                     PixivHelper.print_and_log('warn', f'Skipping image_id: {image_id} – it\'s older than: {config.dateDiff} day(s).')
                     download_image_flag = False
                     result = PixivConstant.PIXIVUTIL_SKIP_OLDER
 
-        if useblacklist:
+        if not metadata_only and useblacklist:
             if config.useBlacklistMembers and download_image_flag:
                 if image.originalArtist is not None and str(image.originalArtist.artistId) in caller.__blacklistMembers:
                     PixivHelper.print_and_log('warn', f'Skipping image_id: {image_id} – blacklisted member id: {image.originalArtist.artistId}')

--- a/handler/PixivImageHandler.py
+++ b/handler/PixivImageHandler.py
@@ -95,6 +95,7 @@ def process_image(caller,
     parse_medium_page = None
     image = None
     result = None
+    manga_files = []
     if not is_unlisted:
         # https://www.pixiv.net/en/artworks/76656661
         referer = f"https://www.pixiv.net/artworks/{image_id}"
@@ -283,7 +284,6 @@ def process_image(caller,
                 target_dir = user_dir
 
             result = PixivConstant.PIXIVUTIL_OK
-            manga_files = list()
             page = 0
 
             # Issue #639

--- a/handler/PixivTagsHandler.py
+++ b/handler/PixivTagsHandler.py
@@ -9,7 +9,46 @@ import common.PixivBrowserFactory as PixivBrowserFactory
 import common.PixivConstant as PixivConstant
 import common.PixivHelper as PixivHelper
 import handler.PixivImageHandler as PixivImageHandler
+from common.PixivException import PixivException
 from model.PixivTags import PixivTags
+
+
+def process_tag_metadata(caller, config, tags, notifier=None):
+    if notifier is None:
+        notifier = PixivHelper.dummy_notifier
+
+    db = caller.__dbManager__
+    if isinstance(tags, str):
+        tags_list = [t.strip() for t in tags.split(',') if t.strip()]
+    else:
+        tags_list = tags
+
+    for tag in tags_list:
+        msg = f'Processing Tag Metadata: {tag}'
+        PixivHelper.print_and_log('info', msg)
+        notifier(type="TAG", message=msg)
+        try:
+            tag_info = PixivBrowserFactory.getBrowser().getTagInfo(tag, lang=config.tagTranslationLocale)
+            tag_id = tag_info.tag or tag_info.word or tag
+            db.insertTag(tag_id)
+            db.updateTag(tag_id)
+
+            tag_translations = tag_info.tagTranslation or {}
+            for key_tag, translations in tag_translations.items():
+                if key_tag:
+                    db.insertTag(key_tag)
+                    db.updateTag(key_tag)
+                if translations:
+                    for locale, value in translations.items():
+                        if value:
+                            db.insertTagTranslation(key_tag, locale, value)
+        except Exception as ex:
+            if isinstance(ex, KeyboardInterrupt):
+                raise
+            caller.ERROR_CODE = getattr(ex, 'errorCode', -1)
+            PixivHelper.print_and_log('error', f'Error at process_tag_metadata(): {tag}')
+            PixivHelper.print_and_log('error', f'Exception: {sys.exc_info()}')
+            continue
 
 
 def process_tags(caller,

--- a/handler/PixivTagsHandler.py
+++ b/handler/PixivTagsHandler.py
@@ -13,7 +13,7 @@ from common.PixivException import PixivException
 from model.PixivTags import PixivTags
 
 
-def process_tag_metadata(caller, config, tags, notifier=None):
+def process_tag_metadata(caller, config, tags, filter_mode="none", notifier=None):
     if notifier is None:
         notifier = PixivHelper.dummy_notifier
 
@@ -30,6 +30,18 @@ def process_tag_metadata(caller, config, tags, notifier=None):
         try:
             tag_info = PixivBrowserFactory.getBrowser().getTagInfo(tag, lang=config.tagTranslationLocale)
             tag_id = tag_info.tag or tag_info.word or tag
+
+            has_pixpedia = tag_info.pixpedia is not None and bool(tag_info.pixpedia.tag)
+            has_translation = bool(tag_info.tagTranslation)
+            if filter_mode == "pixpedia" and not has_pixpedia:
+                PixivHelper.print_and_log('info', f"Skipping tag without pixpedia: {tag_id}")
+                continue
+            if filter_mode == "translation" and not has_translation:
+                PixivHelper.print_and_log('info', f"Skipping tag without translation: {tag_id}")
+                continue
+            if filter_mode == "pixpedia_or_translation" and not (has_pixpedia or has_translation):
+                PixivHelper.print_and_log('info', f"Skipping tag without pixpedia/translation: {tag_id}")
+                continue
             db.insertTag(tag_id)
             db.updateTag(tag_id)
 

--- a/test/test_PixivHelper.py
+++ b/test/test_PixivHelper.py
@@ -331,6 +331,13 @@ class TestPixivHelper(unittest.TestCase):
         # print(r)
         self.assertTrue(len(r) > 0)
 
+    def testCoalesce(self):
+        self.assertIsNone(PixivHelper.coalesce())
+        self.assertIsNone(PixivHelper.coalesce(None, None))
+        self.assertEqual(PixivHelper.coalesce(None, 0, 1), 0)
+        self.assertEqual(PixivHelper.coalesce(None, "a", "b"), "a")
+        self.assertEqual(PixivHelper.coalesce(None, None, "fallback"), "fallback")
+
 
 if __name__ == '__main__':
     # unittest.main()

--- a/test/test_PixivHelper.py
+++ b/test/test_PixivHelper.py
@@ -45,6 +45,15 @@ class TestPixivHelper(unittest.TestCase):
         self.assertEqual(result, expected)
         self.assertTrue(len(result) < 255)
 
+    def testCoalesceNonEmptyString(self):
+        self.assertEqual(PixivHelper.coalesce(None, "", "a"), "a")
+        self.assertEqual(PixivHelper.coalesce("", None, "a"), "a")
+        self.assertEqual(PixivHelper.coalesce("", " ", None), " ")
+        self.assertEqual(PixivHelper.coalesce(0, "", None), 0)
+        self.assertEqual(PixivHelper.coalesce("", 0), 0)
+        self.assertIsNone(PixivHelper.coalesce(None, "", None))
+        self.assertIsNone(PixivHelper.coalesce("", None))
+
     def testSanitizeFilename3(self):
         rootDir = 'D:\\Temp\\Pixiv2\\'
         if platform.system() != 'Windows':


### PR DESCRIPTION
As time progresses, metadata of artworks may be outdated, or incomplete due to introduction of new features (e.g. saving by caption, tag, series), and re-downloading all content including images may not be necessary.

This PR/feature spec aims adds options to forcefully update metadata by ID, through additional command line entrypoints m1-m4. Details below.

Commands:

- m1: download member metadata by ID
- m2: download image metadata by ID
- m3: download series metadata by ID
- m4: download tag metadata by ID

For all table fields, coalesce, update, and default generally follow these rules: the "freshest" data is saved to database.

- API response if not null always overrides.
- If API response field null, database field value if not null shall not be overwritten.
- If both API and database fields are null, apply default if default is specified.

## download artist metadata by ID

This will download and update the `pixiv_master_member` row only. While other member update methods may or may not update, this method should *always* update the corresponding row.

("default" means: update if field does not exist with default value)

- member_id -> update
- name -> update
- save_folder -> update to `N\A` (not saving content, so this is enforced)
- created_date -> coalesce default now
- last_update_date -> update (to now)
- last_image -> coalesce, update or default -1
- is_deleted -> coalesce, update or default 0
- member_token -> coalesce, update or default null

E.g.: update member info by ID -> makes ajax call to member info. If member info exists, fetches member info from db, then applies update with coalesce

Unlike the content download option "1", download artist metadata by ID *only* downloads the metadata of the artist, not images posted by the artist. However, we may have an argument for including image metadata (and corresponding tags/series) owned by artist. This is currently not planned.

configs blocking this (e.g. autoAddMember) would be ignored. Otherwise m1 has no point.

## download image metadata by ID

Download and update image, member, series, and tag tables + mapping tables. This follows the existing image handler logic, but should always update, so check for `insert or ignore`.

Image/tag metadata updates are overwriting, not additive. That means: remove all existing image/tag associations by this image ID, and re-apply image/tag mappings. Also, remove image/series associations, and re-apply image/series mappings.

For example:

- if image metadata has no series, check if image is part of series, and remove mappings.
- if image metadata has series, check if image mapping is correct, else update series metadata (see download series metadata by ID).
- always overwrite image/tag associations: delete existing mappings, then re-apply mappings corresponding to current image tag.
- always update artist info with coalesce or default null.

An important point: because download image metadata by ID does not download images, `pixiv_manga_image` shall NOT be updated.

An m2-unique note: Metadata download types are still subject to config flags. For example, caption data will never be downloaded even through this entrypoint, as long as config doesn't permit it. Same applies to auto add series/tag/member.

Config flags are prioritized over freshness. Put another way, config flags gover whether a field can be written to (updated/deleted). If config flag is disabled for an extra field, then the corresponding field may not be touched.

An exception applies if this is existing behavior (e.g. captions). In the case of captions, disabling autoAddCaption would overwrite existing captions with empty string. May require further discussion.

## download series metadata by ID

Download and update `pixiv_master_series` and `pixiv_image_to_series_map". This should delete existing image/series associations, and update the map table with new image/series associations, even if the image metadata does not exist in `pixiv_master_image` or is saved locally.

Metadata for image does not need to be fetched.

- series_id -> update
- series_title -> update
- series_type -> update
- series_description -> update
- created_date -> coalesce or default now
- last_update_date -> update

This is not affected by config auto add series flag.

## download tag metadata by ID

Download and update `pixiv_master_tag` and `pixiv_tag_translation`. Do NOT delete existing tag translations; if a translation is missing, keep old translation. However, new translations of the same language override the current translation in database.

`pixiv_master_tag`:
- tag_id -> same
- created_date -> coalesce or default now
- last_update_date -> update

`pixiv_tag_translation`:
- tag_id -> same
- translation_type -> same
- translation -> update
- created_date -> coalesce or default now
- last_update_date -> update

Note: Pixiv allows any string (at least afaik) to be a tag. Therefore, an option exists to only save tags which have a pixpedia entry/have translations. However, know that not all recognized tags may have these entries; therefore, use "m4" responsibly.

This is not affected by config auto add tag flag.

---

While I do not use the command line, I intend to apply these changes for downstream use by PixivUtil server, as metadata management becomes an increasing downstream concern. Please take a look when you have time, thanks.